### PR TITLE
[FE-301] Build collect-current-month wizard with provider selector

### DIFF
--- a/apps/web/e2e/testing-pyramid.e2e.spec.ts
+++ b/apps/web/e2e/testing-pyramid.e2e.spec.ts
@@ -8,12 +8,9 @@ test('renders app shell', async ({ page }) => {
   await page.getByRole('button', { name: 'Sign in (stub)' }).click();
 
   await expect(page.getByRole('heading', { name: 'Invoices Web' })).toBeVisible();
-  await page.getByRole('link', { name: 'Providers' }).click();
+  await page.getByRole('link', { name: 'Collections' }).click();
 
-  await expect(page.getByRole('heading', { name: 'Provider settings' })).toBeVisible();
-  await expect(page.getByTestId('provider-card-gmail')).toBeVisible();
-  await expect(page.getByTestId('provider-card-outlook')).toBeVisible();
-  await expect(
-    page.getByTestId('provider-card-gmail').getByRole('button', { name: 'Connect' }),
-  ).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Collect current month' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Start collection run' })).toBeVisible();
+  await expect(page.getByLabel('Month scope')).toBeVisible();
 });

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -180,6 +180,60 @@
   border-color: #fecaca;
 }
 
+.collection-wizard {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.collection-wizard__fieldset {
+  border: 1px solid #dbe4ee;
+  border-radius: 10px;
+  margin: 0;
+  padding: 0.75rem;
+}
+
+.collection-wizard__fieldset legend {
+  font-size: 0.9rem;
+  font-weight: 700;
+  padding: 0 0.35rem;
+}
+
+.collection-wizard__providers {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.collection-wizard__provider-option {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.collection-wizard__provider-option input {
+  height: 1rem;
+  margin: 0;
+  width: 1rem;
+}
+
+.collection-wizard__month {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.collection-wizard__month span {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.collection-wizard__month-input {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  min-height: 44px;
+  padding: 0.5rem 0.65rem;
+}
+
 .provider-grid {
   display: grid;
   gap: 1rem;

--- a/apps/web/src/features/collections/api/createCollectionJob.integration.test.ts
+++ b/apps/web/src/features/collections/api/createCollectionJob.integration.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { createCollectionJob } from './createCollectionJob';
+import {
+  collectionJobCreateSuccessHandler,
+  collectionJobCreateValidationErrorHandler,
+} from '../../../test/msw/handlers';
+import { server } from '../../../test/msw/server';
+
+describe('createCollectionJob', () => {
+  it('creates a collection job and returns initial run details', async () => {
+    server.use(collectionJobCreateSuccessHandler);
+
+    const result = await createCollectionJob({
+      month_scope: '2026-03',
+      providers: ['gmail'],
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.job.id).toBe('col-1');
+      expect(result.job.status).toBe('queued');
+      expect(result.job.providers).toEqual(['gmail']);
+      expect(result.job.month_scope).toBe('2026-03');
+      expect(result.requestId).toBe('req-col-1');
+      expect(result.status).toBe(201);
+    }
+  });
+
+  it('normalizes backend validation errors', async () => {
+    server.use(collectionJobCreateValidationErrorHandler);
+
+    const result = await createCollectionJob({
+      month_scope: '2026-03',
+      providers: [],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('providers must be a non-empty list');
+      expect(result.error.requestId).toBe('req-col-2');
+      expect(result.error.status).toBe(400);
+    }
+  });
+});

--- a/apps/web/src/features/collections/api/createCollectionJob.ts
+++ b/apps/web/src/features/collections/api/createCollectionJob.ts
@@ -1,0 +1,83 @@
+import { apiClient, getApiRequestId, normalizeApiError, type ApiError } from '../../../shared/api/client';
+
+export type CollectionProvider = 'gmail' | 'outlook';
+
+export type CollectionJobStatus = 'queued' | 'running' | 'succeeded' | 'failed';
+
+export interface CollectionJob {
+  id: string;
+  status: CollectionJobStatus;
+  providers: CollectionProvider[];
+  month_scope: string;
+  created_at?: string | null;
+  updated_at?: string | null;
+  error_message?: string | null;
+  files_discovered?: number | null;
+  files_downloaded?: number | null;
+}
+
+export interface CreateCollectionJobRequest {
+  providers: CollectionProvider[];
+  month_scope: string;
+}
+
+export type CreateCollectionJobResult =
+  | {
+      ok: true;
+      requestId?: string;
+      status: number;
+      job: CollectionJob;
+    }
+  | {
+      ok: false;
+      error: ApiError;
+    };
+
+const createIdempotencyKey = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `collection-${crypto.randomUUID()}`;
+  }
+
+  return `collection-${Date.now()}`;
+};
+
+// OpenAPI snapshot currently does not include /v1/collection-jobs;
+// use a contract-typed adapter until schema is updated.
+export const createCollectionJob = async (
+  payload: CreateCollectionJobRequest,
+): Promise<CreateCollectionJobResult> => {
+  const result = await apiClient.post<CollectionJob, unknown>({
+    body: payload,
+    headers: {
+      'Content-Type': 'application/json',
+      'Idempotency-Key': createIdempotencyKey(),
+    },
+    security: [{ name: 'X-API-Key', type: 'apiKey' }],
+    url: '/v1/collection-jobs',
+  });
+
+  if (result.error !== undefined) {
+    return {
+      ok: false,
+      error: await normalizeApiError(result.error, result.response),
+    };
+  }
+
+  if (result.data === undefined) {
+    return {
+      ok: false,
+      error: {
+        message: 'Collection create response was empty',
+        requestId: getApiRequestId(result.response),
+        status: result.response.status,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    job: result.data,
+    requestId: getApiRequestId(result.response),
+    status: result.response.status,
+  };
+};

--- a/apps/web/src/pages/CollectionWizardPage.integration.test.tsx
+++ b/apps/web/src/pages/CollectionWizardPage.integration.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { CollectionWizardPage } from './CollectionWizardPage';
+import type {
+  CreateCollectionJobRequest,
+  CreateCollectionJobResult,
+} from '../features/collections/api/createCollectionJob';
+
+const toCurrentMonthScope = (): string => {
+  const now = new Date();
+  return `${now.getFullYear()}-${`${now.getMonth() + 1}`.padStart(2, '0')}`;
+};
+
+describe('CollectionWizardPage', () => {
+  it('submits default current-month payload and shows started run details', async () => {
+    const submitCollectionJob = vi
+      .fn<(payload: CreateCollectionJobRequest) => Promise<CreateCollectionJobResult>>()
+      .mockResolvedValue({
+        job: {
+          id: 'col-happy-1',
+          month_scope: toCurrentMonthScope(),
+          providers: ['gmail'],
+          status: 'queued',
+        },
+        ok: true,
+        requestId: 'req-col-happy',
+        status: 201,
+      });
+
+    render(<CollectionWizardPage submitCollectionJob={submitCollectionJob} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Start collection run' }));
+
+    await waitFor(() => {
+      expect(submitCollectionJob).toHaveBeenCalledWith({
+        month_scope: toCurrentMonthScope(),
+        providers: ['gmail'],
+      });
+      expect(screen.getByText('Run started')).toBeInTheDocument();
+      expect(screen.getByText(/col-happy-1/)).toBeInTheDocument();
+      expect(screen.getByText(/queued/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state when submit request fails', async () => {
+    const submitCollectionJob = vi
+      .fn<(payload: CreateCollectionJobRequest) => Promise<CreateCollectionJobResult>>()
+      .mockResolvedValue({
+        error: {
+          message: 'collection queue unavailable',
+        },
+        ok: false,
+      });
+
+    render(<CollectionWizardPage submitCollectionJob={submitCollectionJob} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Start collection run' }));
+
+    await waitFor(() => {
+      expect(submitCollectionJob).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole('alert')).toHaveTextContent('collection queue unavailable');
+    });
+  });
+});

--- a/apps/web/src/pages/CollectionWizardPage.tsx
+++ b/apps/web/src/pages/CollectionWizardPage.tsx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import {
+  createCollectionJob,
+  type CollectionJob,
+  type CollectionProvider,
+  type CreateCollectionJobRequest,
+  type CreateCollectionJobResult,
+} from '../features/collections/api/createCollectionJob';
+
+type CollectionWizardPageProps = {
+  submitCollectionJob?: (payload: CreateCollectionJobRequest) => Promise<CreateCollectionJobResult>;
+};
+
+const COLLECTION_PROVIDERS: CollectionProvider[] = ['gmail', 'outlook'];
+
+const providerLabel: Record<CollectionProvider, string> = {
+  gmail: 'Gmail',
+  outlook: 'Outlook',
+};
+
+const toCurrentMonthScope = (date: Date): string => {
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  return `${date.getFullYear()}-${month}`;
+};
+
+const isValidMonthScope = (value: string): boolean => /^\d{4}-(0[1-9]|1[0-2])$/.test(value);
+
+const upsertProvider = (
+  providers: CollectionProvider[],
+  provider: CollectionProvider,
+  isChecked: boolean,
+): CollectionProvider[] => {
+  if (isChecked) {
+    return providers.includes(provider) ? providers : [...providers, provider];
+  }
+
+  return providers.filter((item) => item !== provider);
+};
+
+export function CollectionWizardPage({ submitCollectionJob = createCollectionJob }: CollectionWizardPageProps) {
+  const [monthScope, setMonthScope] = useState<string>(toCurrentMonthScope(new Date()));
+  const [providers, setProviders] = useState<CollectionProvider[]>(['gmail']);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [createdJob, setCreatedJob] = useState<CollectionJob | null>(null);
+  const [requestId, setRequestId] = useState<string | undefined>(undefined);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setErrorMessage(null);
+    setCreatedJob(null);
+    setRequestId(undefined);
+
+    if (!isValidMonthScope(monthScope)) {
+      setErrorMessage('Month scope must use YYYY-MM format.');
+      return;
+    }
+
+    if (providers.length === 0) {
+      setErrorMessage('Select at least one provider.');
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const response = await submitCollectionJob({
+      month_scope: monthScope,
+      providers,
+    });
+
+    if (!response.ok) {
+      setErrorMessage(response.error.message);
+      setIsSubmitting(false);
+      return;
+    }
+
+    setCreatedJob(response.job);
+    setRequestId(response.requestId);
+    setIsSubmitting(false);
+  };
+
+  return (
+    <section className="app">
+      <header className="app__header">
+        <h2>Collect current month</h2>
+        <p>Start a collection run in one step with provider selection and month defaults.</p>
+      </header>
+
+      <form className="collection-wizard" onSubmit={handleSubmit}>
+        <fieldset className="collection-wizard__fieldset">
+          <legend>Providers</legend>
+          <div className="collection-wizard__providers">
+            {COLLECTION_PROVIDERS.map((provider) => (
+              <label className="collection-wizard__provider-option" key={provider}>
+                <input
+                  checked={providers.includes(provider)}
+                  name={`provider-${provider}`}
+                  onChange={(event) => {
+                    setProviders((currentProviders) =>
+                      upsertProvider(currentProviders, provider, event.target.checked),
+                    );
+                  }}
+                  type="checkbox"
+                />
+                <span>{providerLabel[provider]}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <label className="collection-wizard__month">
+          <span>Month scope</span>
+          <input
+            className="collection-wizard__month-input"
+            name="month_scope"
+            onChange={(event) => setMonthScope(event.target.value)}
+            type="month"
+            value={monthScope}
+          />
+        </label>
+
+        <button className="app__button" disabled={isSubmitting} type="submit">
+          {isSubmitting ? 'Starting run...' : 'Start collection run'}
+        </button>
+      </form>
+
+      {errorMessage && (
+        <section className="app__panel app__panel--error" role="alert">
+          <h3>Could not start collection run</h3>
+          <p>{errorMessage}</p>
+        </section>
+      )}
+
+      {createdJob && (
+        <section className="app__panel">
+          <h3>Run started</h3>
+          <p>
+            Collection run <code>{createdJob.id}</code> is now <strong>{createdJob.status}</strong>.
+          </p>
+          <p>
+            Providers: {createdJob.providers.map((provider) => providerLabel[provider]).join(', ')}
+          </p>
+          <p>Month scope: {createdJob.month_scope}</p>
+          {requestId ? <p>request-id: {requestId}</p> : null}
+        </section>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/routes/AppRoutes.tsx
+++ b/apps/web/src/routes/AppRoutes.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { AppShell } from '../components/shell/AppShell';
 import { DashboardPage } from '../pages/DashboardPage';
+import { CollectionWizardPage } from '../pages/CollectionWizardPage';
 import { ProviderSettingsScreen } from '../features/providers/components/ProviderSettingsScreen';
 import { LoginPage } from '../pages/LoginPage';
 import { PlaceholderPage } from '../pages/PlaceholderPage';
@@ -17,7 +18,7 @@ export function AppRoutes() {
           <Route element={<Navigate replace to="/dashboard" />} index />
           <Route element={<DashboardPage />} path="/dashboard" />
           <Route element={<ProviderSettingsScreen />} path="/providers" />
-          <Route element={<PlaceholderPage title="Collections" />} path="/collections" />
+          <Route element={<CollectionWizardPage />} path="/collections" />
           <Route element={<PlaceholderPage title="Reports" />} path="/reports" />
           <Route element={<PlaceholderPage title="Settings" />} path="/settings" />
         </Route>

--- a/apps/web/src/test/msw/handlers.ts
+++ b/apps/web/src/test/msw/handlers.ts
@@ -3,6 +3,7 @@ import { http, HttpResponse } from 'msw';
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://127.0.0.1:18000';
 
 export const DASHBOARD_SUMMARY_URL = `${API_BASE_URL}/v1/dashboard/summary`;
+export const COLLECTION_JOBS_URL = `${API_BASE_URL}/v1/collection-jobs`;
 
 export const dashboardSummarySuccessHandler = http.get(DASHBOARD_SUMMARY_URL, () =>
   HttpResponse.json(
@@ -37,6 +38,41 @@ export const dashboardSummaryUnauthorizedHandler = http.get(DASHBOARD_SUMMARY_UR
         'x-request-id': 'req-int-2',
       },
       status: 401,
+    },
+  ),
+);
+
+export const collectionJobCreateSuccessHandler = http.post(COLLECTION_JOBS_URL, async ({ request }) => {
+  const payload = (await request.json()) as { month_scope: string; providers: string[] };
+
+  return HttpResponse.json(
+    {
+      created_at: '2026-03-20T09:00:00+00:00',
+      id: 'col-1',
+      month_scope: payload.month_scope,
+      providers: payload.providers,
+      status: 'queued',
+      updated_at: '2026-03-20T09:00:00+00:00',
+    },
+    {
+      headers: {
+        'x-request-id': 'req-col-1',
+      },
+      status: 201,
+    },
+  );
+});
+
+export const collectionJobCreateValidationErrorHandler = http.post(COLLECTION_JOBS_URL, () =>
+  HttpResponse.json(
+    {
+      detail: 'providers must be a non-empty list',
+    },
+    {
+      headers: {
+        'x-request-id': 'req-col-2',
+      },
+      status: 400,
     },
   ),
 );

--- a/docs/frontend/FE_OPENAPI_CLIENT_PLAN.md
+++ b/docs/frontend/FE_OPENAPI_CLIENT_PLAN.md
@@ -181,3 +181,12 @@ Convention:
   - regenerate client (`npm run api:generate`);
   - replace local adapter methods with generated operations;
   - keep UI state contracts unchanged (`connected` / `disconnected` / `error`) to minimize migration risk.
+
+## 14. Week 4 Dependency Note (`FE-301` -> `BE-201`)
+
+- Current committed OpenAPI snapshot still does not include `/v1/collection-jobs` operations.
+- Frontend collection wizard (`FE-301`) uses a typed manual adapter for `POST /v1/collection-jobs` following `docs/contracts/COLLECTION_JOBS_WEEK4_CONTRACT.md`.
+- When collection job endpoints are added to OpenAPI:
+  - regenerate client (`npm run api:generate`);
+  - replace manual collection adapter call-sites with generated operations;
+  - keep request/response UI contracts intact (`providers`, `month_scope`, initial run `id/status`).

--- a/docs/qa/PR_TRACEABILITY_RULES_TEMPLATE.json
+++ b/docs/qa/PR_TRACEABILITY_RULES_TEMPLATE.json
@@ -1,44 +1,43 @@
 {
   "requirements": [
     {
-      "source": "docs/FRONTEND_GITHUB_ISSUES.md",
-      "requirement": "FE-201 provider settings UI supports connect/disconnect/re-auth actions",
+      "source": "docs/PRD_V1_SAAS.md",
+      "requirement": "Collection run start UX exists with current-month wizard entry point",
       "scope": "diff",
       "patterns": [
-        "Provider settings",
-        "Connect",
-        "Disconnect",
-        "Re-auth"
+        "Collect current month",
+        "Start collection run",
+        "month_scope"
       ],
       "on_missing": "FAIL"
     },
     {
-      "source": "docs/contracts/PROVIDER_WEEK3_CONTRACT.md",
-      "requirement": "Provider types include gmail and outlook",
+      "source": "docs/ARCHITECTURE.md",
+      "requirement": "Collection jobs create flow uses collection-jobs endpoint contract",
       "scope": "diff",
       "patterns": [
-        "'gmail'",
-        "'outlook'"
+        "/v1/collection-jobs",
+        "providers",
+        "Idempotency-Key"
       ],
       "on_missing": "FAIL"
     },
     {
-      "source": "docs/contracts/PROVIDER_WEEK3_CONTRACT.md",
-      "requirement": "Provider connection states include connected/disconnected/error",
+      "source": "docs/PRD_V1_SAAS.md",
+      "requirement": "Initial run status is surfaced to the user",
       "scope": "diff",
       "patterns": [
-        "'connected'",
-        "'disconnected'",
-        "'error'"
+        "'queued'",
+        "Run started"
       ],
       "on_missing": "FAIL"
     },
     {
-      "source": "docs/FRONTEND_GITHUB_ISSUES.md",
-      "requirement": "FE-201 includes a failure-path test for provider action handling",
+      "source": "docs/PRD_V1_SAAS.md",
+      "requirement": "Collection wizard includes a failure-path test",
       "scope": "diff",
       "patterns": [
-        "renders a recoverable action error when connect fails"
+        "shows error state when submit request fails"
       ],
       "on_missing": "FAIL"
     }


### PR DESCRIPTION
## Problem Statement
The app was missing a collection start flow for the first web demo. `/collections` was still a placeholder and users could not start a current-month run with provider selection.

## Linked Issues
Closes #20

## Summary
- add a new collection wizard page at `/collections` with mobile-first layout
- add provider selector (`gmail`, `outlook`) and current-month default (`YYYY-MM`)
- add submit flow for `POST /v1/collection-jobs` using a typed manual adapter
- add loading, validation, error, and success states including initial run `id`/`status`
- wire `/collections` route to real page instead of placeholder
- extend tests:
  - collection API integration (happy + failure)
  - collection page integration (happy + failure)
  - update e2e smoke to validate collection wizard route
- update FE OpenAPI plan with Week 4 dependency note for collection endpoints
- update traceability rules for FE-301 strict validation

## Design Notes
- Current OpenAPI snapshot still does not expose `/v1/collection-jobs`, so FE-301 uses a typed manual adapter (`createCollectionJob`) as a contract-safe bridge.
- Adapter uses `apiClient` transport/auth/timeout/error normalization and sends `Idempotency-Key`.
- UI keeps payload contract aligned with Week 4 collection contract (`providers`, `month_scope`) to simplify migration once OpenAPI is updated.

## Reviewer Guide
- `apps/web/src/pages/CollectionWizardPage.tsx`: wizard UX, defaults, and state transitions
- `apps/web/src/features/collections/api/createCollectionJob.ts`: typed POST adapter and normalized error path
- `apps/web/src/features/collections/api/createCollectionJob.integration.test.ts`: API happy/failure coverage
- `apps/web/src/pages/CollectionWizardPage.integration.test.tsx`: UI happy/failure coverage
- `apps/web/src/routes/AppRoutes.tsx`: route wiring for `/collections`

## Testing
- `cd apps/web && npm run test:unit`
- `cd apps/web && npm run test:integration`
- `cd apps/web && npm run lint`
- `cd apps/web && npm run typecheck`
- `cd apps/web && npm run build`
- `cd apps/web && npm run test:e2e`

## Rollout / Risk Notes
- BE dependency: full generated-client wiring depends on BE/OpenAPI update for collection job endpoints.
- Risk is limited to manual adapter path until OpenAPI catches up.
- Migration path is adapter-local (replace manual call with generated operation).

## Summary by Sourcery

Add a new collections wizard page that can start current-month collection runs with provider selection, backed by a manual API adapter for creating collection jobs and updated routing.

New Features:
- Introduce a collection wizard UI at /collections with provider selection and current-month defaults.
- Add a typed manual adapter and client-side types for POST /v1/collection-jobs to start collection runs.

Enhancements:
- Style the collection wizard with dedicated CSS for mobile-first layout and form controls.

Documentation:
- Document the frontend dependency on future OpenAPI support for collection job endpoints in the FE OpenAPI client plan.

Tests:
- Add integration tests for the collection wizard page covering success and error flows.
- Extend MSW handlers and add integration coverage for the createCollectionJob API adapter.
- Update the e2e smoke test to exercise the collections wizard instead of the providers placeholder.