### PR TITLE
[FE-403] Add report artifact download actions

### DIFF
--- a/apps/web/src/features/reports/api/reportArtifactDownloads.ts
+++ b/apps/web/src/features/reports/api/reportArtifactDownloads.ts
@@ -1,0 +1,70 @@
+import { frontendEnv } from '../../../shared/config/env';
+import { normalizeApiError, type ApiError } from '../../../shared/api/client';
+
+export type ReportArtifactDownloadResult =
+  | {
+      ok: true;
+      blob: Blob;
+      fileName: string;
+    }
+  | {
+      ok: false;
+      error: ApiError;
+    };
+
+const extensionByFormat: Record<string, string> = {
+  csv: 'csv',
+  json: 'json',
+  pdf: 'pdf',
+  summary_csv: 'summary.csv',
+};
+
+const buildFileName = (reportId: string, format: string): string =>
+  `${reportId}.${extensionByFormat[format] ?? format}`;
+
+export const saveDownloadedBlob = (blob: Blob, fileName: string) => {
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  document.body.append(link);
+  link.click();
+  link.remove();
+  window.URL.revokeObjectURL(url);
+};
+
+export const downloadReportArtifact = async (
+  reportId: string,
+  format: string,
+): Promise<ReportArtifactDownloadResult> => {
+  try {
+    const response = await fetch(
+      `${frontendEnv.apiBaseUrl}/v1/reports/${encodeURIComponent(reportId)}/download?format=${encodeURIComponent(format)}`,
+      {
+        headers: frontendEnv.apiKey
+          ? {
+              'X-API-Key': frontendEnv.apiKey,
+            }
+          : undefined,
+      },
+    );
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: await normalizeApiError(new Error(`Download failed with HTTP ${response.status}`), response),
+      };
+    }
+
+    return {
+      ok: true,
+      blob: await response.blob(),
+      fileName: buildFileName(reportId, format),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: await normalizeApiError(error),
+    };
+  }
+};

--- a/apps/web/src/features/reports/components/ReportArtifactDownloads.integration.test.tsx
+++ b/apps/web/src/features/reports/components/ReportArtifactDownloads.integration.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ReportArtifactDownloads } from './ReportArtifactDownloads';
+
+describe('ReportArtifactDownloads', () => {
+  it('renders download buttons for requested formats and disables missing artifacts', async () => {
+    render(
+      <ReportArtifactDownloads
+        artifacts={[{ bytes: 2048, format: 'json', id: 'artifact-1', storagePath: 'artifacts/report.json' }]}
+        reportId="report-123"
+        requestedFormats={['json', 'csv']}
+      />,
+    );
+
+    const buttons = screen.getAllByRole('button', { name: 'Download' });
+
+    expect(buttons[0]).toBeEnabled();
+    expect(screen.getByText('JSON')).toBeInTheDocument();
+    expect(screen.getByText('CSV')).toBeInTheDocument();
+    expect(buttons[1]).toBeDisabled();
+  });
+
+  it('downloads an available artifact', async () => {
+    const startDownload = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: new Blob(['{"ok":true}'], { type: 'application/json' }),
+      fileName: 'report-123.json',
+    });
+    const saveBlob = vi.fn();
+
+    render(
+      <ReportArtifactDownloads
+        artifacts={[{ bytes: 2048, format: 'json', id: 'artifact-1', storagePath: 'artifacts/report.json' }]}
+        reportId="report-123"
+        requestedFormats={['json']}
+        saveBlob={saveBlob}
+        startDownload={startDownload}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Download' }));
+
+    await waitFor(() => {
+      expect(startDownload).toHaveBeenCalledWith('report-123', 'json');
+      expect(saveBlob).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/features/reports/components/ReportArtifactDownloads.tsx
+++ b/apps/web/src/features/reports/components/ReportArtifactDownloads.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import type { ReportArtifact, ReportFormat } from '../model/report';
+import {
+  downloadReportArtifact,
+  saveDownloadedBlob,
+} from '../api/reportArtifactDownloads';
+
+type ReportArtifactDownloadsProps = {
+  artifacts: ReportArtifact[];
+  reportId: string;
+  requestedFormats: ReportFormat[];
+  startDownload?: typeof downloadReportArtifact;
+  saveBlob?: typeof saveDownloadedBlob;
+};
+
+const formatLabel: Record<string, string> = {
+  csv: 'CSV',
+  json: 'JSON',
+  pdf: 'PDF',
+  summary_csv: 'Summary CSV',
+};
+
+export function ReportArtifactDownloads({
+  artifacts,
+  reportId,
+  requestedFormats,
+  startDownload = downloadReportArtifact,
+  saveBlob = saveDownloadedBlob,
+}: ReportArtifactDownloadsProps) {
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [downloadingFormat, setDownloadingFormat] = useState<string | null>(null);
+  const artifactsByFormat = new Map(artifacts.map((artifact) => [artifact.format, artifact]));
+  const formatsToRender = requestedFormats.length > 0 ? requestedFormats : [...artifactsByFormat.keys()];
+
+  const handleDownload = async (format: string) => {
+    setDownloadError(null);
+    setDownloadingFormat(format);
+
+    const result = await startDownload(reportId, format);
+    setDownloadingFormat(null);
+
+    if (!result.ok) {
+      setDownloadError(result.error.message);
+      return;
+    }
+
+    saveBlob(result.blob, result.fileName);
+  };
+
+  return (
+    <>
+      {downloadError && (
+        <section className="app__panel app__panel--error" role="alert">
+          <h3>Could not download artifact</h3>
+          <p>{downloadError}</p>
+        </section>
+      )}
+
+      <ul className="report-detail__artifact-list">
+        {formatsToRender.map((format) => {
+          const artifact = artifactsByFormat.get(format);
+          const isAvailable = artifact !== undefined;
+
+          return (
+            <li className="report-detail__artifact" key={format}>
+              <div>
+                <strong>{formatLabel[format] ?? format}</strong>
+                <p className="report-card__meta">
+                  {isAvailable
+                    ? artifact.bytes === null
+                      ? 'Ready to download'
+                      : `${artifact.bytes.toLocaleString()} bytes`
+                    : 'Not available yet'}
+                </p>
+              </div>
+              <button
+                className="app__button"
+                disabled={!isAvailable || downloadingFormat === format}
+                onClick={() => void handleDownload(format)}
+                type="button"
+              >
+                {downloadingFormat === format ? 'Downloading...' : 'Download'}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </>
+  );
+}

--- a/apps/web/src/features/reports/components/ReportDetailScreen.integration.test.tsx
+++ b/apps/web/src/features/reports/components/ReportDetailScreen.integration.test.tsx
@@ -58,7 +58,7 @@ describe('ReportDetailScreen', () => {
 
     expect(screen.getByText('Report detail')).toBeInTheDocument();
     expect(screen.getByText('Succeeded')).toBeInTheDocument();
-    expect(screen.getByText('json')).toBeInTheDocument();
+    expect(screen.getByText('JSON')).toBeInTheDocument();
     expect(screen.getByText('2,048 bytes')).toBeInTheDocument();
   });
 

--- a/apps/web/src/features/reports/components/ReportDetailScreen.tsx
+++ b/apps/web/src/features/reports/components/ReportDetailScreen.tsx
@@ -5,8 +5,9 @@ import {
   reportCreationAdapter,
   type ReportCreationAdapter,
 } from '../api/reportCreationAdapter';
-import type { ReportArtifact, ReportItem, ReportStatus } from '../model/report';
+import type { ReportItem, ReportStatus } from '../model/report';
 import { isTerminalReportStatus } from '../model/report';
+import { ReportArtifactDownloads } from './ReportArtifactDownloads';
 
 type ReportDetailScreenProps = {
   adapter?: ReportCreationAdapter;
@@ -36,9 +37,6 @@ const formatTimestamp = (value: string | null): string => {
     timeStyle: 'short',
   }).format(new Date(parsed));
 };
-
-const formatArtifactBytes = (artifact: ReportArtifact): string =>
-  artifact.bytes === null ? 'Size unavailable' : `${artifact.bytes.toLocaleString()} bytes`;
 
 export function ReportDetailScreen({
   adapter = reportCreationAdapter,
@@ -229,14 +227,11 @@ export function ReportDetailScreen({
             {report.artifacts.length === 0 ? (
               <p>No artifacts available yet.</p>
             ) : (
-              <ul className="report-detail__artifact-list">
-                {report.artifacts.map((artifact) => (
-                  <li className="report-detail__artifact" key={artifact.id}>
-                    <strong>{artifact.format}</strong>
-                    <span>{formatArtifactBytes(artifact)}</span>
-                  </li>
-                ))}
-              </ul>
+              <ReportArtifactDownloads
+                artifacts={report.artifacts}
+                reportId={report.id}
+                requestedFormats={report.requestedFormats}
+              />
             )}
           </section>
 


### PR DESCRIPTION
## Problem Statement
The report detail view could show artifact metadata, but users still had no way to download the actual JSON/CSV/SUMMARY/PDF outputs for completed reports.

## Linked Issues
Closes #26

## Summary
- add a dedicated artifact download client that fetches report files with the configured API key
- add a reusable `ReportArtifactDownloads` component with per-format availability and download actions
- wire report detail to render download controls for requested report formats and cover the behavior with integration tests

## Design Notes
- this PR is intentionally stacked on `codex/vega-fe-402` until FE-402 merges; before final merge it will be rebased onto `origin/main`
- downloads use direct `fetch` with the existing `VITE_API_KEY` header because artifact endpoints return file bodies, not JSON envelopes
- unavailable requested formats stay visible but disabled so users can distinguish `not requested` from `not ready`

## Reviewer Guide
- open a completed report detail screen and confirm available artifacts show `Download` actions
- review `reportArtifactDownloads.ts` for the fetch/blob/file-save flow
- review `ReportArtifactDownloads.tsx` for enabled/disabled per-format behavior and error handling

## Testing
- `npm run test:integration -- ReportArtifactDownloads ReportDetailScreen`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

## Rollout / Risk Notes
- this stacked PR should not merge before FE-402 lands on `main`
- browser download behavior still depends on the presence of a configured API key and object-URL support in the client environment
