### PR TITLE
fix: use dependency-aware services for demo stack startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,14 +144,14 @@ run-monthly: ## Download current-month invoices (Gmail+Outlook) and consolidate 
 run-n8n: ## Start n8n (dev compose only)
 	docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml up -d --build n8n
 
-run-saas-demo-up: ## Start SaaS demo stack (saas-api + rq worker + redis)
-	docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml up -d --build redis saas-api saas-rq-worker
+run-saas-demo-up: ## Start SaaS demo stack (saas-api + rq worker; dependencies auto-start)
+	docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml up -d --build saas-api saas-rq-worker
 
 run-saas-demo-down: ## Stop SaaS demo stack services
-	docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml stop saas-api saas-rq-worker redis
+	docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml stop saas-api saas-rq-worker
 
 run-saas-demo-logs: ## Tail SaaS demo stack logs
-	docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml logs -f saas-api saas-rq-worker redis
+	docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml logs -f saas-api saas-rq-worker
 
 quarantine: ## Move non-invoice PDFs into quarantine/
 	PYTHONPATH=$(PYTHONPATH_EXTRA):$$PYTHONPATH $(PYTHON) -m invplatform.cli.quarantine_invoices

--- a/docs/STAKEHOLDER_DEMO_RUNBOOK.md
+++ b/docs/STAKEHOLDER_DEMO_RUNBOOK.md
@@ -26,7 +26,7 @@ Use this narrative in the first minute:
 
 ```bash
 export SAAS_CONTROL_PLANE_API_KEY=dev-control-plane-key
-docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml up -d --build redis saas-api saas-rq-worker
+docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml up -d --build saas-api saas-rq-worker
 docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml ps
 ```
 
@@ -50,7 +50,7 @@ export FILE_PATH="/absolute/path/to/invoice.pdf"
 ```bash
 if ! curl -fsS "$BASE_URL/healthz" >/dev/null; then
   echo "SaaS API is not reachable at $BASE_URL"
-  echo "Start stack: docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml up -d --build redis saas-api saas-rq-worker"
+  echo "Start stack: docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml up -d --build saas-api saas-rq-worker"
   exit 1
 fi
 
@@ -368,12 +368,12 @@ curl -fsS "$BASE_URL/metrics" | head -n 30
 ## 16) Fast Troubleshooting
 
 ```bash
-docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml logs --tail=120 saas-api saas-rq-worker redis
-docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml up -d --build saas-api saas-rq-worker redis
+docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml logs --tail=120 saas-api saas-rq-worker
+docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml up -d --build saas-api saas-rq-worker
 ```
 
 ## 17) Stop Demo Stack
 
 ```bash
-docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml stop saas-api saas-rq-worker redis
+docker compose --env-file .env -f deploy/compose/docker-compose.dev.yml stop saas-api saas-rq-worker
 ```


### PR DESCRIPTION
## Problem Statement

## Linked Issues

- Closes #<issue_number>

## Summary

## Design Notes

## Reviewer Guide

## Backend Architecture Review

- Status: `<Approved | N/A>`
- Reviewed By: `<@be-architect | N/A>`
- Notes: `<key backend boundary, data, tenancy, performance, security comments>`

## Frontend Architecture Review

- Status: `<Approved | N/A>`
- Reviewed By: `<@fe-architect | N/A>`
- Notes: `<key frontend state, routing, component boundaries, UX-system comments>`

## Testing

- Unit:
- Integration:
- E2E:

## Rollout / Risk Notes

## Summary by Sourcery

Update SaaS demo stack orchestration to rely on dependency-aware Docker Compose service startup instead of explicitly managing Redis.

Enhancements:
- Simplify Makefile SaaS demo commands to start, stop, and tail logs only for core services while letting Docker Compose handle dependent services automatically.

Documentation:
- Adjust stakeholder demo runbook commands to match the new dependency-aware Docker Compose usage for starting, troubleshooting, and stopping the demo stack.